### PR TITLE
Bugfix: delete_buckets raises an error

### DIFF
--- a/lib/hammer_backend_redis.ex
+++ b/lib/hammer_backend_redis.ex
@@ -166,7 +166,7 @@ defmodule Hammer.Backend.Redis do
           {:ok, 0}
 
         {:ok, keys} ->
-          {:ok, [count_deleted, _]} =
+          {:ok, [_, _, _, [count_deleted, _]]} =
             Redix.pipeline(r, [
               ["MULTI"],
               ["DEL" | keys],

--- a/test/hammer_backend_redis_test.exs
+++ b/test/hammer_backend_redis_test.exs
@@ -268,7 +268,7 @@ defmodule HammerBackendRedisTest do
 
     with_mock Redix,
       command: fn _r, _c -> {:ok, ["a", "b"]} end,
-      pipeline: fn _r, _c -> {:ok, [2, nil]} end do
+      pipeline: fn _r, _c -> {:ok, ["OK", "QUEUED", "QUEUED", [2, 2]]} end do
       assert {:ok, 2} = Hammer.Backend.Redis.delete_buckets(pid, "one")
       assert called(Redix.command(:_, ["SMEMBERS", "Hammer:Redis:Buckets:one"]))
 


### PR DESCRIPTION
Currently `delete_buckets` would raise an error as `{:ok, [count_deleted, _]}` is not the right pattern matching for the pipeline. This PR fixes the issue.

See also: https://redis.io/topics/transactions