### PR TITLE
Return count upon bucket creation

### DIFF
--- a/lib/hammer_backend_redis.ex
+++ b/lib/hammer_backend_redis.ex
@@ -258,7 +258,7 @@ defmodule Hammer.Backend.Redis do
 
     case result do
       {:ok, ["OK", "QUEUED", "QUEUED", "QUEUED", "QUEUED", ["OK", 1, 1, 1]]} ->
-        {:ok, 1}
+        {:ok, increment}
 
       {:ok, ["OK", "QUEUED", "QUEUED", "QUEUED", "QUEUED", nil]} ->
         do_count_hit(r, key, now, increment, expiry, attempt + 1)

--- a/test/hammer_backend_redis_test.exs
+++ b/test/hammer_backend_redis_test.exs
@@ -72,7 +72,7 @@ defmodule HammerBackendRedisTest do
       pipeline: fn _r, _c ->
         {:ok, ["OK", "QUEUED", "QUEUED", "QUEUED", "QUEUED", ["OK", 1, 1, 1]]}
       end do
-      assert {:ok, 1} == Hammer.Backend.Redis.count_hit(pid, {1, "one"}, 123, 21)
+      assert {:ok, 21} == Hammer.Backend.Redis.count_hit(pid, {1, "one"}, 123, 21)
       assert called(Redix.command(:_, ["EXISTS", "Hammer:Redis:one:1"]))
 
       assert called(


### PR DESCRIPTION
Calling `do_count_hit` will return `{:ok, count}` if the bucket was already created. If a bucket needed to be created (i.e. the first time this is called), `do_count_hit` would always return `{:ok, 1}`. 

The counts are stored correctly, but the initial return is misleading. Here's an example of what we have in production.

First call costs 30, but since `{:ok, 1}` was returned, we let the user know that they still have 599 points left:
![image](https://user-images.githubusercontent.com/12286657/63711790-3bcc8c80-c80a-11e9-84c1-0aed9c9d542a.png)

The next call also costs 30, but since `{:ok, 60}` was returned, we're able to correctly inform the user of the cost: 
![image](https://user-images.githubusercontent.com/12286657/63711811-438c3100-c80a-11e9-8ce9-1dd4f6a1b78c.png)
