### PR TITLE
Update README to Include redis_url Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/ExHammer/hammer-backend-redis/badge.svg?branch=master)](https://coveralls.io/github/ExHammer/hammer-backend-redis?branch=master)
 
-
 A Redis backend for the [Hammer](https://github.com/ExHammer/hammer) rate-limiter.
 
 ## Installation
@@ -22,18 +21,30 @@ end
 
 ## Usage
 
-Configure the `:hammer` application to use the Redis backend:
+There are a couple ways to configure the `:hammer` application to use the Redis backend:
 
 ```elixir
 config :hammer,
-  backend: {Hammer.Backend.Redis, [expiry_ms: 60_000 * 60 * 2,
-                                   redix_config: [host: "localhost",
-                                                  port: 6379]]}
+  backend: {Hammer.Backend.Redis, [
+    expiry_ms: 60_000 * 60 * 2,
+    redix_config: [
+      host: "localhost",
+      port: 6379
+    ]
+  ]}
 ```
 
 (the `redix_config` arg is a keyword-list which is passed to
 [Redix](https://hex.pm/packages/redix), it's also aliased to `redis_config`,
 with an `s`)
+
+```elixir
+config :hammer,
+  backend: {Hammer.Backend.Redis, [
+    expiry_ms: 60_000 * 60 * 2,
+    redis_url: "localhost:6379"
+  ]
+```
 
 And that's it, calls to `Hammer.check_rate/3` and so on will use Redis to store
 the rate-limit counters.
@@ -43,7 +54,6 @@ See the [Hammer Tutorial](https://hexdocs.pm/hammer/tutorial.html) for more.
 ## Documentation
 
 On hexdocs: [https://hexdocs.pm/hammer_backend_redis/](https://hexdocs.pm/hammer_backend_redis/)
-
 
 ## Getting Help
 


### PR DESCRIPTION
The README did not include an example configuration for Redis via the `redis_url`. I'm updating it to include an example of this configuration.