### PR TITLE
Add config to customise the Redis prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Configure the `:hammer` application to use the Redis backend:
 ```elixir
 config :hammer,
   backend: {Hammer.Backend.Redis, [delete_buckets_timeout: 10_0000,
+                                   key_prefix: "my_application:rate_limiter",
                                    expiry_ms: 60_000 * 60 * 2,
                                    redix_config: [host: "localhost",
                                                   port: 6379]]}
@@ -41,6 +42,7 @@ the redis_url will be used first.
 ```elixir
 config :hammer,
   backend: {Hammer.Backend.Redis, [delete_buckets_timeout: 10_0000,
+                                   key_prefix: "my_application:rate_limiter",
                                    expiry_ms: 60_000 * 60 * 2,
                                    redis_url: "redis://HOST:PORT"]}
 ```

--- a/lib/hammer_backend_redis.ex
+++ b/lib/hammer_backend_redis.ex
@@ -17,6 +17,7 @@ defmodule Hammer.Backend.Redis do
     used to set TTL on Redis keys. This configuration is mandatory.
   - `redix_config`: Keyword list of options to the `Redix` redis client,
     also aliased to `redis_config`
+  - `key_prefix`: The prefix to use for all the redis keys (defaults to "Hammer:Redis:")
   - `redis_url`: String url of redis server to connect to
     (optional, invokes Redix.start_link/2)
   """
@@ -98,6 +99,8 @@ defmodule Hammer.Backend.Redis do
       raise RuntimeError, "Missing required config: expiry_ms"
     end
 
+    key_prefix = Keyword.get(args, :key_prefix, "Hammer:Redis:")
+
     redix_config =
       Keyword.get(
         args,
@@ -116,7 +119,13 @@ defmodule Hammer.Backend.Redis do
 
     delete_buckets_timeout = Keyword.get(args, :delete_buckets_timeout, 5000)
 
-    {:ok, %{redix: redix, expiry_ms: expiry_ms, delete_buckets_timeout: delete_buckets_timeout}}
+    {:ok,
+     %{
+       redix: redix,
+       expiry_ms: expiry_ms,
+       delete_buckets_timeout: delete_buckets_timeout,
+       key_prefix: key_prefix
+     }}
   end
 
   @impl GenServer
@@ -124,15 +133,15 @@ defmodule Hammer.Backend.Redis do
     {:stop, :normal, :ok, state}
   end
 
-  def handle_call({:count_hit, key, now, increment}, _from, %{redix: r} = state) do
+  def handle_call({:count_hit, key, now, increment}, _from, state) do
     expiry = get_expiry(state)
 
-    result = do_count_hit(r, key, now, increment, expiry)
+    result = do_count_hit(state, key, now, increment, expiry)
     {:reply, result, state}
   end
 
   def handle_call({:get_bucket, key}, _from, %{redix: r} = state) do
-    redis_key = make_redis_key(key)
+    redis_key = make_redis_key(state, key)
     command = ["HMGET", redis_key, "count", "created", "updated"]
 
     result =
@@ -154,7 +163,7 @@ defmodule Hammer.Backend.Redis do
   end
 
   def handle_call({:delete_buckets, id}, _from, %{redix: r} = state) do
-    redis_key_pattern = make_redis_key_pattern(id)
+    redis_key_pattern = make_redis_key_pattern(state, id)
     result = do_delete_buckets(r, redis_key_pattern, 0, 0)
 
     {:reply, result, state}
@@ -192,8 +201,8 @@ defmodule Hammer.Backend.Redis do
   # we are using the first method described (called bucketing)
   # in https://www.youtube.com/watch?v=CRGPbCbRTHA
   # but we add the 'created' and 'updated' meta information fields.
-  defp do_count_hit(r, key, now, increment, expiry) do
-    redis_key = make_redis_key(key)
+  defp do_count_hit(%{redix: r} = state, key, now, increment, expiry) do
+    redis_key = make_redis_key(state, key)
 
     cmds = [
       ["MULTI"],
@@ -232,12 +241,12 @@ defmodule Hammer.Backend.Redis do
     end
   end
 
-  defp make_redis_key({bucket, id}) do
-    "Hammer:Redis:#{id}:#{bucket}"
+  defp make_redis_key(%{key_prefix: key_prefix}, {bucket, id}) do
+    "#{key_prefix}#{id}:#{bucket}"
   end
 
-  defp make_redis_key_pattern(id) do
-    "Hammer:Redis:#{id}:*"
+  defp make_redis_key_pattern(%{key_prefix: key_prefix}, id) do
+    "#{key_prefix}#{id}:*"
   end
 
   defp get_expiry(state) do

--- a/test/hammer_backend_redis_test.exs
+++ b/test/hammer_backend_redis_test.exs
@@ -9,25 +9,29 @@ defmodule HammerBackendRedisTest do
     %{redix: redix} = :sys.get_state(pid)
 
     assert {:ok, "OK"} = Redix.command(redix, ["FLUSHALL"])
-    {:ok, [pid: pid, redix: redix]}
+    {:ok, [pid: pid, redix: redix, key_prefix: Keyword.get(config, :key_prefix, "Hammer:Redis:")]}
   end
 
-  test "count_hit, insert", %{pid: pid, redix: redix} do
+  test "count_hit, insert", %{pid: pid, redix: redix, key_prefix: key_prefix} do
     bucket = 1
     id = "one"
     bucket_key = {bucket, id}
     now = 123
     now_str = Integer.to_string(now)
 
-    assert {:ok, 0} = Redix.command(redix, ["EXISTS", make_redis_key(bucket_key)])
+    assert {:ok, 0} = Redix.command(redix, ["EXISTS", make_redis_key(key_prefix, bucket_key)])
     assert {:ok, 1} == Backend.Redis.count_hit(pid, bucket_key, now)
-    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(bucket_key)])
+    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(key_prefix, bucket_key)])
 
     assert {:ok, ["count", "1", "created", ^now_str, "updated", ^now_str]} =
-             Redix.command(redix, ["HGETALL", make_redis_key(bucket_key)])
+             Redix.command(redix, ["HGETALL", make_redis_key(key_prefix, bucket_key)])
   end
 
-  test "count_hit, insert, with custom increment", %{pid: pid, redix: redix} do
+  test "count_hit, insert, with custom increment", %{
+    pid: pid,
+    redix: redix,
+    key_prefix: key_prefix
+  } do
     bucket = 1
     id = "one"
     bucket_key = {bucket, id}
@@ -37,13 +41,13 @@ defmodule HammerBackendRedisTest do
     inc_str = Integer.to_string(inc)
 
     assert {:ok, inc} == Backend.Redis.count_hit(pid, bucket_key, now, inc)
-    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(bucket_key)])
+    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(key_prefix, bucket_key)])
 
     assert {:ok, ["count", ^inc_str, "created", ^now_str, "updated", ^now_str]} =
-             Redix.command(redix, ["HGETALL", make_redis_key(bucket_key)])
+             Redix.command(redix, ["HGETALL", make_redis_key(key_prefix, bucket_key)])
   end
 
-  test "count_hit, update", %{pid: pid, redix: redix} do
+  test "count_hit, update", %{pid: pid, redix: redix, key_prefix: key_prefix} do
     # 1. set-up
     bucket = 1
     id = "one"
@@ -54,14 +58,14 @@ defmodule HammerBackendRedisTest do
     now_after_str = Integer.to_string(now_after)
 
     assert {:ok, 1} == Backend.Redis.count_hit(pid, bucket_key, now_before)
-    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(bucket_key)])
+    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(key_prefix, bucket_key)])
 
     # 2. function call under test: count == 2
     assert {:ok, 2} == Backend.Redis.count_hit(pid, bucket_key, now_after)
-    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(bucket_key)])
+    assert {:ok, 1} = Redix.command(redix, ["EXISTS", make_redis_key(key_prefix, bucket_key)])
 
     assert {:ok, ["count", "2", "created", ^now_before_str, "updated", ^now_after_str]} =
-             Redix.command(redix, ["HGETALL", make_redis_key(bucket_key)])
+             Redix.command(redix, ["HGETALL", make_redis_key(key_prefix, bucket_key)])
   end
 
   test "get_bucket", %{pid: pid} do
@@ -148,7 +152,7 @@ defmodule HammerBackendRedisTest do
     assert 1_000 == length(keys)
   end
 
-  defp make_redis_key({bucket, id}) do
-    "Hammer:Redis:#{id}:#{bucket}"
+  defp make_redis_key(prefix, {bucket, id}) do
+    "#{prefix}#{id}:#{bucket}"
   end
 end


### PR DESCRIPTION
In large Redis cluster security my be controlled by key prefix having no control of this can therefore be problematic.

This PR add the ability to customise the Redis key prefix to something provided in config.