### PR TITLE
use elixir timeout type in bucket specs

### DIFF
--- a/lib/hammer/redis/leaky_bucket.ex
+++ b/lib/hammer/redis/leaky_bucket.ex
@@ -78,7 +78,7 @@ defmodule Hammer.Redis.LeakyBucket do
           leak_rate :: pos_integer(),
           capacity :: pos_integer(),
           cost :: pos_integer(),
-          timeout :: non_neg_integer()
+          timeout :: timeout()
         ) :: {:allow, non_neg_integer()} | {:deny, non_neg_integer()}
   def hit(connection_name, prefix, key, leak_rate, capacity, cost, timeout) do
     {:ok, [allowed, value]} =
@@ -110,7 +110,7 @@ defmodule Hammer.Redis.LeakyBucket do
           connection_name :: atom(),
           prefix :: String.t(),
           key :: String.t(),
-          timeout :: non_neg_integer()
+          timeout :: timeout()
         ) ::
           non_neg_integer()
   def get(connection_name, prefix, key, timeout) do

--- a/lib/hammer/redis/token_bucket.ex
+++ b/lib/hammer/redis/token_bucket.ex
@@ -79,7 +79,7 @@ defmodule Hammer.Redis.TokenBucket do
           refill_rate :: pos_integer(),
           capacity :: pos_integer(),
           cost :: pos_integer(),
-          timeout :: non_neg_integer()
+          timeout :: timeout()
         ) :: {:allow, non_neg_integer()} | {:deny, non_neg_integer()}
   def hit(connection_name, prefix, key, refill_rate, capacity, cost, timeout) do
     {:ok, [allowed, value]} =
@@ -116,7 +116,7 @@ defmodule Hammer.Redis.TokenBucket do
           connection_name :: atom(),
           prefix :: String.t(),
           key :: String.t(),
-          timeout :: non_neg_integer()
+          timeout :: timeout()
         ) ::
           non_neg_integer()
   def get(connection_name, prefix, key, timeout) do


### PR DESCRIPTION
When using the TokenBucket implementation, I ran into issues with the dialyzer because the timeout was set to `:infinity` by default, and the bucket implementations just use `non_neg_integer()` for the timeout typesepc.

This updates the typespecs for the bucket implementations to use Elixir's `timeout()` type instead, which matches what the window implementations already have in place.