### PR TITLE
docs: document Redis 7.0+ requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       matrix:
         include:
           # Latest
+          - elixir: 1.20
+            otp: 29
+          - elixir: 1.20
+            otp: 28
+          # 1.19
           - elixir: 1.19
             otp: 28
           - elixir: 1.19
@@ -83,5 +88,5 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: 1
-          otp-version: 27
+          otp-version: 29
       - run: mix format --check-formatted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       matrix:
         include:
           # Latest
-          - elixir: 1.20
+          - elixir: "1.20"
             otp: 29
-          - elixir: 1.20
+          - elixir: "1.20"
             otp: 28
           # 1.19
           - elixir: 1.19

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.5-otp-28
-erlang 28.3.1
+elixir 1.20.3-otp-29
+erlang 29.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Document that Redis 7.0+ is required (`EXPIREAT ... NX` and `EXPIRETIME` were introduced in Redis 7.0) (#148)
+
 ## 7.1.1 - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ This backend is a thin [Redix](https://hex.pm/packages/redix) wrapper. A single 
 The algorithm we are using is the first method described (called "bucketing") in [Rate Limiting with Redis](https://youtu.be/CRGPbCbRTHA?t=753).
 In other sources it's sometimes called a "fixed window counter".
 
-**TODO:** document ttl issues if servers are misconfigured
+## Requirements
+
+**Redis 7.0 or later is required.** The fixed window algorithm relies on the `NX` option of
+[`EXPIREAT`](https://redis.io/docs/latest/commands/expireat/) and the sliding window algorithm
+relies on [`EXPIRETIME`](https://redis.io/docs/latest/commands/expiretime/), both of which were
+introduced in Redis 7.0.
+
+On older Redis versions (which are [end-of-life](https://endoflife.date/redis)), these commands
+fail, so counter keys never receive a TTL and are never cleaned up. Rate limiting appears to work
+correctly, but the keyspace grows unbounded until Redis runs out of memory.
 
 ## Installation
 

--- a/lib/hammer/redis.ex
+++ b/lib/hammer/redis.ex
@@ -2,6 +2,13 @@ defmodule Hammer.Redis do
   @moduledoc """
   This backend uses the [Redix](https://hex.pm/packages/redix) library to connect to Redis.
 
+  > #### Redis version requirement {: .warning}
+  >
+  > Redis 7.0 or later is required. The `:fix_window` algorithm relies on `EXPIREAT ... NX` and
+  > the `:sliding_window` algorithm relies on `EXPIRETIME`, both introduced in Redis 7.0. On older
+  > Redis versions these commands fail, so counter keys never expire and the keyspace grows until
+  > Redis runs out of memory.
+
       defmodule MyApp.RateLimit do
         # the default prefix is "MyApp.RateLimit:"
         # the default timeout is :infinity

--- a/lib/hammer/redis/fix_window.ex
+++ b/lib/hammer/redis/fix_window.ex
@@ -57,6 +57,12 @@ defmodule Hammer.Redis.FixWindow do
 
       # Allow 10 requests per second
       MyApp.RateLimit.hit("user_123", 1000, 10)
+
+  ## Redis version requirement
+
+  This algorithm sets key expiration with `EXPIREAT ... NX`; the `NX` option requires
+  Redis 7.0 or later. On older Redis versions the command fails, so counter keys never
+  expire and accumulate until Redis runs out of memory.
   """
   @doc false
   @spec hit(

--- a/lib/hammer/redis/sliding_window.ex
+++ b/lib/hammer/redis/sliding_window.ex
@@ -63,6 +63,10 @@ defmodule Hammer.Redis.SlidingWindow do
 
       # Allow 10 requests in any 1 second window
       MyApp.RateLimit.hit("user_123", 1000, 10)
+
+  ## Redis version requirement
+
+  This algorithm relies on the `EXPIRETIME` command, which requires Redis 7.0 or later.
   """
   @doc false
   @spec hit(


### PR DESCRIPTION
## Summary

- Document that **Redis 7.0 or later is required**: the fix window algorithm uses `EXPIREAT ... NX` and the sliding window algorithm uses `EXPIRETIME`, both introduced in Redis 7.0. On older (EOL) Redis versions these commands fail, so counter keys never receive a TTL — rate limiting appears to work while the keyspace grows until Redis runs out of memory.
- Also bumps the dev toolchain to Elixir 1.20.3 / OTP 29.0.5 and adds the Elixir 1.20 / OTP 29 pairs to the CI matrix.

## Changes

- `README.md` - New "Requirements" section (replaces the stale TTL TODO note)
- `lib/hammer/redis.ex` - Warning admonition in the main moduledoc
- `lib/hammer/redis/fix_window.ex` / `lib/hammer/redis/sliding_window.ex` - Per-algorithm version notes
- `CHANGELOG.md` - Unreleased entry
- `.tool-versions` / `.github/workflows/ci.yml` - Elixir 1.20.3 / OTP 29.0.5, CI matrix update

## Test Plan

- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, and `mix test --include redis --include slow` (34 tests) all pass locally on Elixir 1.20.3 / OTP 29.0.5

Fixes #148

---
🤖 Generated with Claude Code by Emmanuel Pinault

https://claude.ai/code/session_01LngV52pvPNSPX9fc8dyTyA