### PR TITLE
fix: surface Redis command errors and drop unused `NX` from `EXPIREAT`

### DIFF
--- a/lib/hammer/redis/fix_window.ex
+++ b/lib/hammer/redis/fix_window.ex
@@ -83,11 +83,10 @@ defmodule Hammer.Redis.FixWindow do
 
     commands = [
       ["INCRBY", full_key, increment],
-      ["EXPIREAT", full_key, div(expires_at, 1000), "NX"]
+      ["EXPIREAT", full_key, div(expires_at, 1000)]
     ]
 
-    [count, _] =
-      Redix.pipeline!(name, commands, timeout: timeout)
+    [count, _] = pipeline!(name, commands, timeout)
 
     if count <= limit do
       {:allow, count}
@@ -113,11 +112,10 @@ defmodule Hammer.Redis.FixWindow do
 
     commands = [
       ["INCRBY", full_key, increment],
-      ["EXPIREAT", full_key, div(expires_at, 1000), "NX"]
+      ["EXPIREAT", full_key, div(expires_at, 1000)]
     ]
 
-    [count, _] =
-      Redix.pipeline!(name, commands, timeout: timeout)
+    [count, _] = pipeline!(name, commands, timeout)
 
     count
   end
@@ -139,10 +137,10 @@ defmodule Hammer.Redis.FixWindow do
 
     commands = [
       ["SET", full_key, count],
-      ["EXPIREAT", full_key, div(expires_at, 1000), "NX"]
+      ["EXPIREAT", full_key, div(expires_at, 1000)]
     ]
 
-    Redix.pipeline!(name, commands, timeout: timeout)
+    pipeline!(name, commands, timeout)
 
     count
   end
@@ -164,6 +162,17 @@ defmodule Hammer.Redis.FixWindow do
     case count do
       nil -> 0
       count -> String.to_integer(count)
+    end
+  end
+
+  # `Redix.pipeline!/3` raises on connection errors only; a command error is returned as a
+  # `%Redix.Error{}` in the result list.
+  defp pipeline!(name, commands, timeout) do
+    results = Redix.pipeline!(name, commands, timeout: timeout)
+
+    case Enum.find(results, &match?(%Redix.Error{}, &1)) do
+      nil -> results
+      error -> raise error
     end
   end
 

--- a/test/hammer/redis_test.exs
+++ b/test/hammer/redis_test.exs
@@ -43,6 +43,49 @@ defmodule Hammer.RedisTest do
     clean_keys()
   end
 
+  test "a later hit in the same window does not move the expiry", %{key: key} do
+    scale = :timer.hours(1)
+
+    RateLimit.hit(key, scale, 5)
+    [{redis_key, "1"}] = redis_all(key)
+    first_expiry = Redix.command!(RateLimit, ["EXPIRETIME", redis_key])
+
+    RateLimit.hit(key, scale, 5)
+
+    assert Redix.command!(RateLimit, ["EXPIRETIME", redis_key]) == first_expiry
+    assert first_expiry > System.system_time(:second)
+
+    clean_keys()
+  end
+
+  describe "a Redis command error" do
+    test "raises out of hit/4 instead of denying the request", %{key: key} do
+      scale = :timer.hours(1)
+
+      # A wrong-type value makes Redis answer INCRBY with an error reply, as it does for OOM,
+      # MISCONF and READONLY.
+      Redix.command!(RateLimit, ["SET", full_key(key, scale), "not-an-integer"])
+
+      assert_raise Redix.Error, fn -> RateLimit.hit(key, scale, 5) end
+
+      clean_keys()
+    end
+
+    test "raises out of inc/3 rather than returning the error as a count", %{key: key} do
+      scale = :timer.hours(1)
+
+      Redix.command!(RateLimit, ["SET", full_key(key, scale), "not-an-integer"])
+
+      assert_raise Redix.Error, fn -> RateLimit.inc(key, scale) end
+
+      clean_keys()
+    end
+  end
+
+  defp full_key(key, scale) do
+    "Hammer.RedisTest.RateLimit:#{key}:#{div(System.system_time(:millisecond), scale)}"
+  end
+
   test "key has expirytime set", %{key: key} do
     scale = :timer.seconds(10)
     limit = 5


### PR DESCRIPTION
`Redix.pipeline!/3` raises on connection errors only — an error reply to an individual command comes back as a `%Redix.Error{}` inside the result list. That error currently lands as count and because a map sorts above every integer in Erlang term order `count <= limit` is false. A failing Redis then returns a well-formed `{:deny, expires_at - now}` that no caller can tell apart from a genuine over-limit result, so nobody can fail open. Raising puts the failure back on Redix's documented channel.

_Note: this same issue is present in SlidingWindow's `inc/6` and `set/6` as well._

I also removed `NX` from `EXPIREAT`. See inline comments for details.

Fixes #147