### PR TITLE
chore: add mise.toml and bump Elixir to 1.20.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.20.3-otp-29
+elixir 1.20.4-otp-29
 erlang 29.0.5

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "29.0.5"
+elixir = "1.20.4-otp-29"


### PR DESCRIPTION
## Summary

Add a `mise.toml` so [mise](https://mise.jdx.dev) users pick up the pinned toolchain natively, keep `.tool-versions` in sync for asdf users, and bump Elixir 1.20.3 → 1.20.4 (otp-29). Erlang stays at 29.0.5 (current latest).

## Changes

- New `mise.toml` pinning `erlang = "29.0.5"`, `elixir = "1.20.4-otp-29"`
- `.tool-versions` bumped to `elixir 1.20.4-otp-29`

## Test Plan

- [x] `mise install` resolves both tools
- [x] `mix deps.get` + `mix compile` succeed on Elixir 1.20.4 / OTP 29

🤖 Generated with Claude Code by Emmanuel Pinault

https://claude.ai/code/session_01LngV52pvPNSPX9fc8dyTyA