### PR TITLE
Remove Elixir 1.15 and 1.16 from the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,6 @@ jobs:
             otp: 27
           - elixir: 1.17
             otp: 26
-          # Older supported
-          - elixir: 1.16
-            otp: 26
-          - elixir: 1.15
-            otp: 26
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Drops Elixir 1.15 and 1.16 from the CI matrix. Lowest version now tested is 1.17.