### PR TITLE
chore: release 7.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.2.1 - 2026-09-08
+
+### Changed
+
+- No code changes; re-release of 7.2.0
+
 ## 7.2.0 - 2026-09-08
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Hammer.Redis.MixProject do
   use Mix.Project
 
-  @version "7.2.0"
+  @version "7.2.1"
 
   def project do
     [


### PR DESCRIPTION
## Summary

Version bump to 7.2.1 and CHANGELOG update. No code changes — re-release of 7.2.0 (which was tagged/published without going through PR review).

## Changes

- `mix.exs`: `@version` 7.2.0 → 7.2.1
- `CHANGELOG.md`: 7.2.1 section

## After merge

Tag `v7.2.1` on the merge commit (on request) — the tag push triggers the hex.pm publish workflow.

🤖 Generated with Claude Code by Emmanuel Pinault

https://claude.ai/code/session_01LngV52pvPNSPX9fc8dyTyA